### PR TITLE
Downgrade sqlite3 gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,7 +4,7 @@ source 'https://rubygems.org'
 # Bundle edge Rails instead: gem 'rails', github: 'rails/rails'
 gem 'rails', '~> 5.0.0'
 # Use sqlite3 as the database for Active Record
-gem 'sqlite3'
+gem 'sqlite3', '~> 1.3.13'
 # Use Puma as the app server
 gem 'puma', '~> 3.0'
 # Use SCSS for stylesheets

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -132,7 +132,7 @@ GEM
       actionpack (>= 4.0)
       activesupport (>= 4.0)
       sprockets (>= 3.0.0)
-    sqlite3 (1.4.2)
+    sqlite3 (1.3.13)
     thor (1.0.1)
     thread_safe (0.3.6)
     tilt (2.0.10)
@@ -166,7 +166,7 @@ DEPENDENCIES
   sass-rails (~> 5.0)
   spring
   spring-watcher-listen (~> 2.0.0)
-  sqlite3
+  sqlite3 (~> 1.3.13)
   turbolinks (~> 5)
   tzinfo-data
   uglifier (>= 1.3.0)


### PR DESCRIPTION
I had to run some tests to compare the parameters change between Rails 4
and 5, while running `bundle install` I got the following error message:

```
/home/ombu/.asdf/installs/ruby/2.6.10/lib/ruby/gems/2.6.0/gems/activerecord-5.0.7.2/lib/active_record/connection_adapters/connection_specification.rb:176:in `rescue in spec':
Specified 'sqlite3' for database adapter, but the gem is not loaded. Add `gem 'sqlite3'` to your Gemfile (and ensure its version is at the minimum required by ActiveRecord). (Gem::LoadError)
```

so, downgrading the gem fixed the issue.

btw, I was using `ruby 2.6.10`.
